### PR TITLE
Film source

### DIFF
--- a/app/controllers/films_controller.rb
+++ b/app/controllers/films_controller.rb
@@ -6,15 +6,10 @@ class FilmsController < ApplicationController
   def create
     link = film_params[:external_id]
 
-    external_id = ExternalIDExtractor.new(link).perform
-    film = current_user.films.build(film_params.merge({external_id: external_id})) if external_id
+    source_info = ExternalIDExtractor.new(link).perform
+    film = current_user.films.build(film_params.merge(source_info)) if source_info.present?
 
-    if film.save
-      current_user.films.create(film_params.merge({external_id: external_id}))
-      flash[:success] = 'Film added'
-    else
-      flash[:error] = film.errors.full_messages.first
-    end
+    film.save ? flash[:success] = 'Film added' : flash[:error] = film.errors.full_messages.first
 
   rescue StandardError => e
     flash[:error] = e.message

--- a/app/domains/external_id_extractor.rb
+++ b/app/domains/external_id_extractor.rb
@@ -8,7 +8,7 @@ class ExternalIDExtractor
   def perform
     case
     when (yt = Youtube::Extractor.new(uri)).valid_source?
-      yt.extract
+      { external_id: yt.extract, source: :youtube }
     else
       raise StandardError.new('Only YouTube videos are currently supported.')
     end

--- a/app/models/film.rb
+++ b/app/models/film.rb
@@ -2,9 +2,11 @@ class Film < ApplicationRecord
   belongs_to :user
   has_many :applauses, dependent: :destroy
 
-  validates :external_id, uniqueness: true
+  validates :external_id, uniqueness: { scope: :source }
   validates :runtime, numericality: { greater_than: 0,
                                       less_than_or_equal_to: 50,
                                       only_integer: true ,
                                       message: 'can only be whole numbers between 0 and 50 minutes.'}
+
+  enum source: [:youtube, :vimeo]
 end

--- a/bin/one-time/add_youtube_as_source_to_all.rb
+++ b/bin/one-time/add_youtube_as_source_to_all.rb
@@ -1,0 +1,3 @@
+Film.all.each do |film|
+  film.update_attribute(:source, :youtube)
+end

--- a/db/migrate/20180814012018_add_source_to_films.rb
+++ b/db/migrate/20180814012018_add_source_to_films.rb
@@ -1,0 +1,5 @@
+class AddSourceToFilms < ActiveRecord::Migration[5.2]
+  def change
+    add_column :films, :source, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_20_102736) do
+ActiveRecord::Schema.define(version: 2018_08_14_012018) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,6 +32,7 @@ ActiveRecord::Schema.define(version: 2018_06_20_102736) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"
+    t.integer "source"
     t.index ["user_id"], name: "index_films_on_user_id"
   end
 

--- a/test/controllers/films_controller_test.rb
+++ b/test/controllers/films_controller_test.rb
@@ -9,7 +9,7 @@ class FilmsControllerTest < ActionDispatch::IntegrationTest
         {
           title: 'Hotel Cevalier',
           runtime: 13,
-          external_id: 'https://youtu.be/stock-id1'
+          external_id: 'https://youtu.be/stock-id1',
         }.merge(opts)
       }
     end

--- a/test/domains/external_id_extractor_test.rb
+++ b/test/domains/external_id_extractor_test.rb
@@ -10,7 +10,7 @@ class ExternalIDExtractorTest < ActiveSupport::TestCase
     mock.expect(:extract, EX_ID)
 
     Youtube::Extractor.stub(:new, mock) do
-      assert_equal(EX_ID, ExternalIDExtractor.new(GOOD_URL).perform)
+      assert_equal({external_id: EX_ID, source: :youtube}, ExternalIDExtractor.new(GOOD_URL).perform)
     end
 
     assert_mock(mock)

--- a/test/fixtures/films.yml
+++ b/test/fixtures/films.yml
@@ -5,11 +5,13 @@ one:
   title: 'Hotel Chevalier'
   runtime: 13
   user: kyle
+  source: youtube
 
 two:
   external_id: 'otxlzSMcBTo'
   title: 'The Big Shave'
   runtime: john
+  source: youtube
 
 # These were taking a really long time to load for the system tests.
 # Since we're not executing those tests, I'm also commenting this out

--- a/test/models/film_test.rb
+++ b/test/models/film_test.rb
@@ -1,11 +1,19 @@
 require 'test_helper'
 
 class FilmTest < ActiveSupport::TestCase
+  test 'allow duplicates from different sources' do
+    user = users(:kyle)
+
+    assert_difference('Film.count') do
+      user.films.create(title: 'Another title', runtime: 10, external_id: films(:one).external_id, source: :vimeo)
+    end
+  end
+
   test 'ensure no duplicates' do
     user = users(:kyle)
 
     assert_no_difference('Film.count') do
-      user.films.create(title: 'New name', runtime: 14, external_id: films(:one).external_id)
+      user.films.create(title: 'New name', runtime: 14, external_id: films(:one).external_id, source: :youtube)
     end
   end
 
@@ -13,7 +21,7 @@ class FilmTest < ActiveSupport::TestCase
     user = users(:kyle)
 
     assert_no_difference('Film.count') do
-      user.films.create(title: 'New name', runtime: -1, external_id: "#{films(:one).external_id}2")
+      user.films.create(title: 'New name', runtime: -1, external_id: "#{films(:one).external_id}2", source: :youtube)
     end
   end
 
@@ -21,7 +29,7 @@ class FilmTest < ActiveSupport::TestCase
     user = users(:kyle)
 
     assert_no_difference('Film.count') do
-      user.films.create(title: 'New name', runtime: 60, external_id: "#{films(:one).external_id}2")
+      user.films.create(title: 'New name', runtime: 60, external_id: "#{films(:one).external_id}2", source: :youtube)
     end
   end
 
@@ -29,7 +37,7 @@ class FilmTest < ActiveSupport::TestCase
     user = users(:kyle)
 
     assert_no_difference('Film.count') do
-      user.films.create(title: 'New name', runtime: 'yellow', external_id: "#{films(:one).external_id}2")
+      user.films.create(title: 'New name', runtime: 'yellow', external_id: "#{films(:one).external_id}2", source: :youtube)
     end
   end
 end


### PR DESCRIPTION
This adds the source field to film as a `enum` with two options: `youtube`, `vimeo`. It also fixes all the tests, controllers, and extractor. It includes a one-off script to add `:youtube` to all current films.

We need to ensure this does not break the current process and is seamless. This will need to go out before the Vimeo integration work.